### PR TITLE
fix: fix incorrect Retrieve request type

### DIFF
--- a/lib/backend/layers/toolkit-layer/python/francis_toolkit/retrievers/knowledgebase_retriever.py
+++ b/lib/backend/layers/toolkit-layer/python/francis_toolkit/retrievers/knowledgebase_retriever.py
@@ -94,11 +94,15 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
         *,
         run_manager: CallbackManagerForRetrieverRun,
     ) -> List[Document]:
-        response = self.client.retrieve(
-            retrievalQuery={"text": query.strip()},
-            knowledgeBaseId=self.knowledge_base_id,
-            retrievalConfiguration=self.retrieval_config.dict(exclude_none=True, by_alias=True),
-        )
+        # NOTE TO REVIEWER: nextToken should not have been in the retrievalConfig
+        correct_retrieve_config = self.retrieval_config.model_dump(exclude_none=True, by_alias=True)
+        nextToken = correct_retrieve_config.pop("nextToken", None)
+        retrieve_params = {
+            "retrievalQuery": {"text": query.strip()},
+            "knowledgeBaseId": self.knowledge_base_id,
+            "retrievalConfiguration": correct_retrieve_config,
+        }
+        response = self.client.retrieve(**retrieve_params, nextToken=nextToken)
         results = response["retrievalResults"]
         documents = []
         for result in results:


### PR DESCRIPTION
This request type is wrong; nextToken should be an arg, not a member of retrievalConfiguration. This results in ValidationErrors. 

https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_Retrieve.html