### PR TITLE
Retrieve API fix

### DIFF
--- a/lib/backend/layers/toolkit-layer/python/francis_toolkit/retrievers/knowledgebase_retriever.py
+++ b/lib/backend/layers/toolkit-layer/python/francis_toolkit/retrievers/knowledgebase_retriever.py
@@ -94,11 +94,15 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
         *,
         run_manager: CallbackManagerForRetrieverRun,
     ) -> List[Document]:
-        response = self.client.retrieve(
-            retrievalQuery={"text": query.strip()},
-            knowledgeBaseId=self.knowledge_base_id,
-            retrievalConfiguration=self.retrieval_config.dict(exclude_none=True, by_alias=True),
-        )
+        # NOTE TO REVIEWER: nextToken should not have been in the retrievalConfig
+        correct_retrieve_config = self.retrieval_config.model_dump(exclude_none=True, by_alias=True)
+        nextToken = correct_retrieve_config.pop("nextToken", None)
+        retrieve_params = {
+            "retrievalQuery": {"text": query.strip()},
+            "knowledgeBaseId": self.knowledge_base_id,
+            "retrievalConfiguration": correct_retrieve_config,
+        }
+        response = self.client.retrieve(**retrieve_params, nextToken=nextToken)
         results = response["retrievalResults"]
         documents = []
         for result in results:

--- a/lib/backend/layers/toolkit-layer/python/francis_toolkit/retrievers/knowledgebase_retriever.py
+++ b/lib/backend/layers/toolkit-layer/python/francis_toolkit/retrievers/knowledgebase_retriever.py
@@ -101,8 +101,9 @@ class AmazonKnowledgeBasesRetriever(BaseRetriever):
             "retrievalQuery": {"text": query.strip()},
             "knowledgeBaseId": self.knowledge_base_id,
             "retrievalConfiguration": correct_retrieve_config,
+            **({"nextToken": nextToken} if nextToken else {}),
         }
-        response = self.client.retrieve(**retrieve_params, nextToken=nextToken)
+        response = self.client.retrieve(**retrieve_params)
         results = response["retrievalResults"]
         documents = []
         for result in results:


### PR DESCRIPTION
A previous PR mistakenly claimed to correct this. It passed nextToken into the args of the .retrieve call, but if nextToken is None this raises a validation error. 

This PR conditionally includes nextToken.